### PR TITLE
major refactoring of the pmin/pmax reporting rules

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -114,11 +114,10 @@ module.exports = function (qn) {
             if (isReadable) {
                 dataToCheck = data;
                 setImmediate(function () {
-                    reporter.checkAndReportResource(qn, oid, iid, rid, dataToCheck);
+                    var err = reporter.checkAndReportResource(qn, oid, iid, rid, dataToCheck);
+                    callback(!err, data);
                 });
             }
-
-            callback(err, data);
         });
     };
 

--- a/lib/msg_handlers.js
+++ b/lib/msg_handlers.js
@@ -305,7 +305,7 @@ handlers._executeReqHandler = function (qn, trg, msg, cb) {
 handlers._writeAttrsReqHandler = function (qn, trg, msg, cb) {
     var attrs,
         badAttr = false,
-        allowedAttrs = [ 'pmin', 'pmax', 'gt', 'lt', 'stp', 'cancel', 'pintvl' ];
+        allowedAttrs = [ 'pmin', 'pmax', 'gt', 'lt', 'stp', 'cancel', 'pintvl', 'usecache' ];
 
     if (!_.isPlainObject(msg.data)) {
         cb(RSP.badreq, null);

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -17,45 +17,17 @@ reporter.enableReport = function (qn, oid, iid, rid) {
         return false;
 
     if (trg.type === TTYPE.obj) {
-        rpid = okey;
+        return false;
 
-        dumper = function (cb) {
-            so.dump(oid, { restrict: true }, cb);
-        };
-
-        notifier = {
-            oid: mutils.oidNum(oid),
-            data: null
-        };
-
+        //TODO: recursively call this reporter on its instances
     } else if (trg.type === TTYPE.inst) {
-        rpid = okey + ':' + iid;
+        return false;
 
-        dumper = function (cb) {
-            so.dump(oid, iid, { restrict: true }, cb);
-        };
-
-        notifier = {
-            oid: mutils.oidNum(oid),
-            iid: iid,
-            data: null
-        };
-
+        //TODO: recursively call this reporter on the instances resources
     } else if (trg.type === TTYPE.rsc) {
         rkey = mutils.ridKey(oid, rid);
 
         rpid = okey + ':' + iid + ':' + rkey;
-
-        dumper = function (cb) {
-            so.read(oid, iid, rid, { restrict: true }, cb);
-        };
-
-        notifier = {
-            oid: mutils.oidNum(oid),
-            iid: iid,
-            rid: mutils.ridNum(rid),
-            data: null
-        };
     } else {
         return false;
     }
@@ -64,35 +36,31 @@ reporter.enableReport = function (qn, oid, iid, rid) {
     pmax = rAttrs.pmax * 1000;
 
     rAttrs.cancel = false;
-    rAttrs.mute = true;
+    rAttrs.mute = false;
     qn._reporters[rpid] = { min: null, max: null, poller: null };
     rRpt = qn._reporters[rpid];
 
-    // WE DONT USE POLLER AT THIS MOMENT, BUT KEEP THIS SNIPPET HERE
-    // if (trg.type === TTYPE.rsc) {
-    //     rRpt.poller = setInterval(function () {
-    //         so.read(oid, iid, rid, { restrict: true });  // just read it, reporter._checkAndReportResrc() will be invoked
-    //     }, rAttrs.pintvl || 500);
-    // }
-
-    rRpt.min = setTimeout(function () {
-        if (pmin === 0) {             // if no pmin, just report at pmax triggered
-            rAttrs.mute = false;
-        } else {
-            dumper(function (err, val) {
-                rAttrs.mute = false;
-                notifier.data = val;
-                qn.notify(notifier, function () {});
-            });
+    so.read(oid, iid, rid, { restrict: true }, function(err, data) {
+        if(err)
+        {
+            reporter.setTimers(rRpt, rAttrs, so, oid, iid, rid, true);
         }
-    }, pmin);
+    });
+
+    /*if(pmin > 0)
+    {
+        rRpt.min = setTimeout(function () {
+            // if no pmin, just report at pmax triggered
+            rAttrs.mute = false;
+        }, pmin);
+    }
 
     rRpt.max = setInterval(function () {
         rAttrs.mute = true;
         dumper(function (err, val) {
             rAttrs.mute = false;
             notifier.data = val;
-            qn.notify(notifier, function () {});
+            //qn.notify(notifier, function () {});
         });
 
         if (!_.isNil(rRpt.min))
@@ -106,11 +74,11 @@ reporter.enableReport = function (qn, oid, iid, rid) {
                 dumper(function (err, val) {
                     rAttrs.mute = false;
                     notifier.data = val;
-                    qn.notify(notifier, function () {});
+                    //qn.notify(notifier, function () {});
                 });
             }
         }, pmin);
-    }, pmax);
+    }, pmax);*/
 
     return true;
 };
@@ -126,8 +94,10 @@ reporter.disableReport = function (qn, oid, iid, rid) {
         return false;
 
     if (trg.type === TTYPE.obj)
+        //TODO recursively cancel reports on object instance
         rpid = okey;
     else if (trg.type === TTYPE.inst)
+        //TODO recursively cancel reports on instances' resources
         rpid = okey + ':' + iid;
     else if (trg.type === TTYPE.rsc)
         rpid = okey + ':' + iid + ':' + mutils.ridKey(oid, rid);
@@ -244,6 +214,7 @@ reporter.setAttrs = function (qn, oid, iid, rid, attrs) {
     attrs.mute = _.isBoolean(attrs.mute) ? attrs.mute : true;
     attrs.cancel = _.isBoolean(attrs.cancel) ? attrs.cancel : true;
     attrs.lastRpVal = attrs.lastRpVal || null;
+    attrs.usecache = _.isBoolean(attrs.usecache) ? attrs.usecache : false;
     qn._repAttrs[key] = attrs;
 
     return true;
@@ -252,9 +223,17 @@ reporter.setAttrs = function (qn, oid, iid, rid, attrs) {
 reporter.checkAndReportResource = function (qn, oid, iid, rid, currVal) {
     var rAttrs = reporter.getAttrs(qn, oid, iid, rid),  // { pmin, pmax, mute, cancel, lastRpVal }
         rpt = false,
-        gt, lt, step, lastrp;
+        okey = mutils.oidKey(oid),
+        rkey = mutils.ridKey(oid, rid),
+        gt, lt, step, lastrp,
+        rpid = okey + ':' + iid + ':' + rkey,
+        rRpt = qn._reporters[rpid],
+        cachevalues = rAttrs.usecache;
 
     if (_.isNil(rAttrs))
+        return false;
+
+    if (_.isNil(rRpt))
         return false;
 
     gt = rAttrs.gt;
@@ -265,7 +244,10 @@ reporter.checkAndReportResource = function (qn, oid, iid, rid, currVal) {
     if (rAttrs.cancel || rAttrs.mute)
         return false;
 
-    if (_.isObject(currVal)) {
+    if(!cachevalues)
+    {
+        rpt = true
+    } else if (_.isObject(currVal)) {
         if (_.isObject(rAttrs.lastRpVal)) {
             _.forEach(rAttrs.lastRpVal, function (v, k) {
                 rpt = rpt || (v !== rAttrs.lastRpVal[k]);
@@ -294,7 +276,42 @@ reporter.checkAndReportResource = function (qn, oid, iid, rid, currVal) {
         rAttrs.lastRpVal = currVal;
     }
 
+    if((rAttrs.pmin >= rAttrs.pmax) || rpt || (_.isNil(rRpt.max) && rAttrs.pmax > 0)) {
+        reporter.setTimers(rRpt, rAttrs, qn.so, oid, iid, rid)
+    }
+        
     return rpt;
 };
+
+reporter.setTimers = function (rRpt, rAttrs, so, oid, iid, rid, initmute = false)
+{
+    var pmin, pmax;
+
+    pmin = rAttrs.pmin * 1000;
+    pmax = rAttrs.pmax * 1000;
+
+    if (!_.isNil(rRpt.min))
+        clearTimeout(rRpt.min);
+    if (!_.isNil(rRpt.max))
+        clearTimeout(rRpt.max);
+
+    if (pmin > 0) {
+        rAttrs.mute = !initmute;
+        rRpt.min = setTimeout(function () {
+            // if no pmin, just report at pmax triggered
+            rAttrs.mute = false;
+        }, pmin);
+    }
+
+    if (pmax > 0) {
+        rRpt.max = setTimeout(function () {
+            rAttrs.mute = false;
+            rRpt.max = null;
+            setImmediate(function () {
+                so.read(oid, iid, rid, { restrict: true }, function () { })
+            });
+        }, pmax)
+    }
+}
 
 module.exports = reporter;


### PR DESCRIPTION
disabled in function enablereport the possibility to use objects and instances
only direct report on resources possible due to the new mechanism that checkandreportresource is governing function.